### PR TITLE
Improve Newton-Raphson implementation

### DIFF
--- a/math_modules/newton_raphson.js
+++ b/math_modules/newton_raphson.js
@@ -9,16 +9,23 @@ let nthRoot = (n, a) => {
     else if (n === 3)
         return Math.cbrt(a).toPrecision(6);
 
-    let preResult = Math.random() % 10; // Initial guess
+    // Use a deterministic initial guess instead of a random one for
+    // improved stability. `a / n` generally brings us closer to the
+    // final answer than an arbitrary random value.
+    let preResult = a / n;
+
     let eps = Math.pow(10, -6); // Lesser the eps value, more the accuracy
 
     let delX = Number.MAX_SAFE_INTEGER;
     let result;
-
-    while (delX > eps) {
+    let iterations = 0;
+    // Limit the number of iterations to avoid potential infinite loops
+    // when provided with invalid input.
+    while (delX > eps && iterations < 1000) {
         result = ((n - 1.0) * preResult + a/Math.pow(preResult, n-1)) / n;
         delX = Math.abs(result - preResult);
         preResult = result;
+        iterations += 1;
     }
 
     return result.toPrecision(6);


### PR DESCRIPTION
## Summary
- refine initial guess for nth root calculation
- add iteration limit to prevent infinite loops

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842201ec7888333ab06c86a5203619f